### PR TITLE
the paragraph tag is using a font-size of 1em which is overriding the…

### DIFF
--- a/_sass/_06_typography.scss
+++ b/_sass/_06_typography.scss
@@ -330,7 +330,9 @@ mark {
 .footnotes ol { 
     font-size: $font-size-small;
 }
-
+.footnotes p {
+    font-size: inherit;  
+}
 
 
 /* Icon Font


### PR DESCRIPTION
the paragraph tag is using a font-size of 1rem which is overriding the smaller footnote size when used in footnotes.  I added a .footnotes p declaration to override font-size with inherit