### PR TITLE
Configurable header color

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -72,6 +72,8 @@ exclude:
 # The language setting is used in /includes/header.html for html-settings
 language: "en"
 
+#color for headers without image
+header-color: 334D5C
 
 # Used › default.html front-matter and compress.html
 # Options › http://jch.penibelst.de

--- a/assets/css/styles_feeling_responsive.scss
+++ b/assets/css/styles_feeling_responsive.scss
@@ -39,6 +39,14 @@ sitemap:
 
 @import "06_typography.scss";
 @import "07_layout.scss";
+#masthead {
+  background-color: #{{ site.header-color }};
+}
+
+#masthead-no-image-header {
+  background-color: #{{ site.header-color }};
+}
+
 @import "foundation-components/grid";
 @import "09_elements.scss";
 


### PR DESCRIPTION
First let me explain, why I think it would be good to be able to specify this color in a config file:
The color of the header background defines the web page more than the other colors. While in many cases it might be okay to leave the color values at their defaults, the color of the header background most certainly needs to be adapted. 

Regarding the implementation, I am not sure if the duplicate CSS definitions in `styles_feeling_responsive.scss` are okay. 
It is working however.

PS: In an ideal world I imagine a colors.yml file which would define all colors, so one doesn't have to fiddle with many duplicate entries in a bunch of css files :)
