### PR TITLE
Fix minor formatting issue

### DIFF
--- a/_includes/_pagination.html
+++ b/_includes/_pagination.html
@@ -10,7 +10,7 @@
 {% for post in paginator.posts %}
   <div class="row">
     <div class="small-12 columns b60">
-      <p class="subheadline"><span class="subheader">{% if post.categories %}{{ post.categories | join: ' &middot; ' }}{% endif %}</span> – {% if post.subheadline %}{{ post.subheadline }}{% endif %}</p>
+      <p class="subheadline"><span class="subheader">{% if post.categories %}{{ post.categories | join: ' &middot; ' }}{% endif %}</span>{% if post.subheadline %} – {{ post.subheadline }}{% endif %}</p>
       <h2><a href="{{ site.url }}{{ post.url }}">{{ post.title }}</a></h2>
       <p>
         {% if post.image.thumb %}<a href="{{ site.url }}{{ post.url }}" title="{{ post.title escape_once }}"><img src="{{ site.urlimg }}{{ post.image.thumb }}" class="alignleft" width="150" height="150" alt="{{ page.title escape_once }}"></a>{% endif %}


### PR DESCRIPTION
- When the post does not contain a subheadline, there was an ugly '`-`' string trailing after the post's pagination description. 

Normally, a post is rendered with a title and subheadline like this: `MyPostTitle - MyPostSubheadline`, but if there is no subheadline defined, the post is rendered with this title: `MyPostTitle -`. This PR fixes it so the '`-`' string is only included when a subheadline is defined in the post.
