### PR TITLE
Update Gemfile ++ gem 'json'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source 'https://rubygems.org'
 gem 'jekyll', '3.0.2'
 gem 'jekyll-gist'
 gem 'jekyll-paginate'
+
+gem 'json'


### PR DESCRIPTION
Without this line jekyll exits with:

``` sh
~/.gem/ruby/gems/jekyll-3.0.2/lib/jekyll/filters.rb:2:in `require': cannot load such file -- json (LoadError)
```

With this line jekyll works as expected.
