### PR TITLE
Inverted previous and next buttons in next-previous-post-in-category widget

### DIFF
--- a/_includes/next-previous-post-in-category
+++ b/_includes/next-previous-post-in-category
@@ -30,10 +30,10 @@
 {% assign prev_post = post.url %}
 {% endif %}
 {% endfor %}
-{% if next_post %}
-<a class="left button tiny radius icon-chevron-left r15" href="{{ next_post }}">{{ site.data.language.next_post_in }} {{ cat | upcase }}</a>
-{% endif %}
 {% if prev_post %}
-<a class="button tiny radius" href="{{ prev_post }}">{{ site.data.language.previous_post_in }} {{ cat | upcase }}<span class="icon-chevron-right"></span></a>
+<a class="left button tiny radius icon-chevron-left r15" href="{{site.url}}{{site.baseurl}}{{ prev_post }}">{{ site.data.language.previous_post_in }} {{ cat | upcase }}</a>
+{% endif %}
+{% if next_post %}
+<a class="button tiny radius" href="{{site.url}}{{site.baseurl}}{{ next_post }}">{{ site.data.language.next_post_in }} {{ cat | upcase }}<span class="icon-chevron-right"></span></a>
 {% endif %}
 


### PR DESCRIPTION
It looked to me that the buttons were inverted. It might be the case that it's a ltr-rtl issue?
I'm not sure.

However, I put the _previous post_ button to the left and the _next post_ button to the right.

Take a look and let me know if this fixes the issue or if it's just a misconfiguration on my end.
