### PR TITLE
fixed page-format according to jekyll3 change

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -50,7 +50,7 @@
 	{% if site.bing_webmastertools_id %}<meta name="msvalidate.01" content="{{ site.bing_webmastertools_id }}" >{% endif %}
 	{% if site.google_author %}<link rel="author" href="{{ site.google_author }}">{% endif %}
 	{% if site.alexa_verify_id %}<meta name="alexaVerifyID" content="{{ site.alexa_verify_id }}">{% endif %}
-	{% if page.noindex == true %}<meta name="robots" content="noindex">{% endif %}
+	{% if page.noindex == true or layout.noindex == true %}<meta name="robots" content="noindex">{% endif %}
 
 
 	<!-- Facebook Open Graph -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@ layout: compress
 <head>
 	{% include _head.html %}
 </head>
-<body id="top-of-page" class="{{ page.format }}">
+<body id="top-of-page" class="{{ layout.format }}">
 	{% unless page.skip_boilerplate %}
 	{% include _navigation.html %}
 	{% endunless %}


### PR DESCRIPTION
layout metadata needs to be accessed using "format.foo" rather than "page.foo"
fixes #104 
