### PR TITLE
Add gemspec for use as gem based theme

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,53 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    colorator (1.1.0)
+    ffi (1.9.18)
+    forwardable-extended (2.6.0)
+    jekyll (3.6.0)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.14)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (>= 1.7, < 3)
+      safe_yaml (~> 1.0)
+    jekyll-paginate (1.1.0)
+    jekyll-sass-converter (1.5.0)
+      sass (~> 3.4)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    kramdown (1.15.0)
+    liquid (4.0.0)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    pathutil (0.16.0)
+      forwardable-extended (~> 2.6)
+    public_suffix (3.0.0)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    rouge (2.2.1)
+    safe_yaml (1.0.4)
+    sass (3.5.2)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll
+  jekyll-paginate
+
+BUNDLED WITH
+   1.15.4

--- a/jekyll-theme-feeling-responsive.gemspec
+++ b/jekyll-theme-feeling-responsive.gemspec
@@ -1,0 +1,23 @@
+Gem::Specification.new do |s|
+  s.name = 'jekyll-theme-feeling-responsive'
+  s.version = '1.0.0'
+  s.date = '2017-10-09'
+  s.summary = 'a free flexible theme for Jekyll built on Foundation framework'
+  s.description = <<-EOD==
+# Feeling Responsive
+Is a free flexible theme for Jekyll built on Foundation framework.
+You can use it for your company site, as a portfolio or as a blog.
+
+See the [home page](http://phlow.github.io/feeling-responsive/) to get a
+look at the theme and read about its features.
+
+See the [documentation](http://phlow.github.io/feeling-responsive/documentation/)
+to learn how to use the theme effectively in your Jekyll site.
+  EOD
+  s.authors = ['Moritz Sauer', 'Douglas Lovell']
+  s.email = ['https://phlow.de/kontakt.html', 'doug@wbreeze.com']
+  s.files = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|_layouts|_includes|_sass|LICENSE|README)}i) }
+  s.homepage = 'http://phlow.github.io/feeling-responsive/'
+  s.license = 'MIT'
+end
+

--- a/jekyll-theme-feeling-responsive.gemspec
+++ b/jekyll-theme-feeling-responsive.gemspec
@@ -1,12 +1,11 @@
 Gem::Specification.new do |s|
   s.name = 'jekyll-theme-feeling-responsive'
-  s.version = '1.0.1'
+  s.version = '1.0.2'
   s.date = '2017-10-09'
-  s.summary = 'a free flexible theme for Jekyll built on Foundation framework'
+  s.summary = 'A free flexible theme for Jekyll built on Foundation framework'
   s.description = <<EOD
-==
-# Feeling Responsive
-Is a free flexible theme for Jekyll built on Foundation framework.
+== Feeling Responsive
+A free flexible theme for Jekyll built on Foundation framework.
 You can use it for your company site, as a portfolio or as a blog.
 
 See the [home page](http://phlow.github.io/feeling-responsive/) to get a

--- a/jekyll-theme-feeling-responsive.gemspec
+++ b/jekyll-theme-feeling-responsive.gemspec
@@ -1,9 +1,10 @@
 Gem::Specification.new do |s|
   s.name = 'jekyll-theme-feeling-responsive'
-  s.version = '1.0.0'
+  s.version = '1.0.1'
   s.date = '2017-10-09'
   s.summary = 'a free flexible theme for Jekyll built on Foundation framework'
-  s.description = <<-EOD==
+  s.description = <<EOD
+==
 # Feeling Responsive
 Is a free flexible theme for Jekyll built on Foundation framework.
 You can use it for your company site, as a portfolio or as a blog.
@@ -13,9 +14,9 @@ look at the theme and read about its features.
 
 See the [documentation](http://phlow.github.io/feeling-responsive/documentation/)
 to learn how to use the theme effectively in your Jekyll site.
-  EOD
-  s.authors = ['Moritz Sauer', 'Douglas Lovell']
-  s.email = ['https://phlow.de/kontakt.html', 'doug@wbreeze.com']
+EOD
+  s.authors = ['Moritz Sauer']
+  s.email = ['https://phlow.de/kontakt.html']
   s.files = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|_layouts|_includes|_sass|LICENSE|README)}i) }
   s.homepage = 'http://phlow.github.io/feeling-responsive/'
   s.license = 'MIT'


### PR DESCRIPTION
This adds `jekyll-theme-feeling-responsive.gemspec` for building a gem and pushing to [RubyGems](https://rubygems.org/gems/jekyll-theme-feeling-responsive).