### PR TITLE
Add option to remove navigation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@ layout: compress
 	{% include _head.html %}
 </head>
 <body id="top-of-page" class="{{ layout.format }}">
-	{% unless page.skip_boilerplate %}
+	{% unless page.skip_boilerplate or page.skip_navigation %}
 	{% include _navigation.html %}
 	{% endunless %}
 


### PR DESCRIPTION
Adds to the default layout, a check for `page.skip_navigation` before rendering the navigation template.

This enables removing navigation without removing the footer (as `page.skip_boilerplate` will do).

In a page, this looks like:
```
---
layout: page
skip_navigation: true
---
```