### PR TITLE
Do not show logo on full width header if no logo specified

### DIFF
--- a/_includes/_masthead.html
+++ b/_includes/_masthead.html
@@ -52,13 +52,13 @@
 
 <div id="masthead">
 {% if site.logo %}
-  <div class="row">
-    <div class="small-12 columns">
-      <a id="logo" href="{{ site.url }}" title="{{ site.title }} – {{ site.slogan }}">
-        <img src="{{ site.url }}{{ site.baseurl }}/assets/img/{{ site.logo }}" alt="{{ site.title }} – {{ site.slogan }}">
-      </a>
-    </div><!-- /.small-12.columns -->
-  </div><!-- /.row -->
+	<div class="row">
+		<div class="small-12 columns">
+			<a id="logo" href="{{ site.url }}" title="{{ site.title }} – {{ site.slogan }}">
+				<img src="{{ site.url }}{{ site.baseurl }}/assets/img/{{ site.logo }}" alt="{{ site.title }} – {{ site.slogan }}">
+			</a>
+		</div><!-- /.small-12.columns -->
+	</div><!-- /.row -->
 {% endif %}
 </div><!-- /#masthead -->
 

--- a/_includes/_masthead.html
+++ b/_includes/_masthead.html
@@ -1,6 +1,7 @@
 {% if page.header == NULL and page.header.image_fullwidth == NULL and page.header.pattern == NULL and page.header.background-color == NULL and page.header.title == NULL %}
 
 <div id="masthead-no-image-header">
+{% if site.logo %}
 	<div class="row">
 		<div class="small-12 columns">
 			<a id="logo" href="{{ site.url }}" title="{{ site.title }} – {{ site.slogan }}">
@@ -8,6 +9,7 @@
 			</a>
 		</div><!-- /.small-12.columns -->
 	</div><!-- /.row -->
+{% endif %}
 </div><!-- /#masthead -->
 
 {% if page.breadcrumb == true %}
@@ -49,13 +51,15 @@
 {% elsif page.header.image_fullwidth %}
 
 <div id="masthead">
-	<div class="row">
-		<div class="small-12 columns">
-			<a id="logo" href="{{ site.url }}" title="{{ site.title }} – {{ site.slogan }}">
-				<img src="{{ site.url }}{{ site.baseurl }}/assets/img/{{ site.logo }}" alt="{{ site.title }} – {{ site.slogan }}">
-			</a>
-		</div><!-- /.small-12.columns -->
-	</div><!-- /.row -->
+{% if site.logo %}
+  <div class="row">
+    <div class="small-12 columns">
+      <a id="logo" href="{{ site.url }}" title="{{ site.title }} – {{ site.slogan }}">
+        <img src="{{ site.url }}{{ site.baseurl }}/assets/img/{{ site.logo }}" alt="{{ site.title }} – {{ site.slogan }}">
+      </a>
+    </div><!-- /.small-12.columns -->
+  </div><!-- /.row -->
+{% endif %}
 </div><!-- /#masthead -->
 
 {% if page.breadcrumb == true %}

--- a/_includes/_masthead.html
+++ b/_includes/_masthead.html
@@ -1,7 +1,7 @@
 {% if page.header == NULL and page.header.image_fullwidth == NULL and page.header.pattern == NULL and page.header.background-color == NULL and page.header.title == NULL %}
 
-<div id="masthead-no-image-header">
 {% if site.logo %}
+<div id="masthead-no-image-header">
 	<div class="row">
 		<div class="small-12 columns">
 			<a id="logo" href="{{ site.url }}" title="{{ site.title }} – {{ site.slogan }}">
@@ -9,8 +9,8 @@
 			</a>
 		</div><!-- /.small-12.columns -->
 	</div><!-- /.row -->
-{% endif %}
 </div><!-- /#masthead -->
+{% endif %}
 
 {% if page.breadcrumb == true %}
 {% include _breadcrumb.html %}


### PR DESCRIPTION
Prevents simply showing alt text on masthead when there is no specified logo file.