### PR TITLE
Add configuration for info permalink

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,9 @@ slogan: "A Flexible Theme for Jekyll"
 # The description is used on homepage and in the footer to quickly describe your website. Use a maximum of 150 characters for SEO-purposes.
 description: "The description is used on homepage and in the footer to quickly describe your website. Use a maximum of 150 characters for SEO-purposes."
 
+# The permalink of the info page
+info-permalink: /info/
+
 # Main author of the website
 # See > authors.yml
 author: phlow

--- a/_includes/_footer.html
+++ b/_includes/_footer.html
@@ -13,7 +13,7 @@
 
             <p class="shadow-black">
               {{ site.description }}
-              <a href="{{ site.url }}{{ site.baseurl }}/info/">{{ site.data.language.more }}</a>
+              <a href="{{ site.url }}{{ site.baseurl }}{{ site.info-permalink }}">{{ site.data.language.more }}</a>
             </p>
           </div><!-- /.large-6.columns -->
 


### PR DESCRIPTION
Currently the site description 'more' text is hardcoded to link to the **/info** page in **_footer.html**

Here a site configuration `info-permalink` defined in **_config.yml**, permits a user to change the
slug of the link in the site description. This is useful for users that do not want a page URL at **/info**