### PR TITLE
Use imgurl config variable for site logo

### DIFF
--- a/_includes/_masthead.html
+++ b/_includes/_masthead.html
@@ -5,7 +5,7 @@
 	<div class="row">
 		<div class="small-12 columns">
 			<a id="logo" href="{{ site.url }}" title="{{ site.title }} – {{ site.slogan }}">
-				<img src="{{ site.url }}{{ site.baseurl }}/assets/img/{{ site.logo }}" alt="{{ site.title }} – {{ site.slogan }}">
+				<img src="{{ site.urlimg }}/{{ site.logo }}" alt="{{ site.title }} – {{ site.slogan }}">
 			</a>
 		</div><!-- /.small-12.columns -->
 	</div><!-- /.row -->
@@ -55,7 +55,7 @@
 	<div class="row">
 		<div class="small-12 columns">
 			<a id="logo" href="{{ site.url }}" title="{{ site.title }} – {{ site.slogan }}">
-				<img src="{{ site.url }}{{ site.baseurl }}/assets/img/{{ site.logo }}" alt="{{ site.title }} – {{ site.slogan }}">
+				<img src="{{ site.urlimg }}/{{ site.logo }}" alt="{{ site.title }} – {{ site.slogan }}">
 			</a>
 		</div><!-- /.small-12.columns -->
 	</div><!-- /.row -->


### PR DESCRIPTION
The `imgurl` config variable allows the location of site image assets to be hosted at a configurable address.

However the display of the logo on a page header (_masthead template) presumes the address of the logo image to be at `./assets/img/`

This pull request updates the masthead to use the `imgurl` config variable when specifying the logo image source address.