### PR TITLE
Adjust h1...h5 headings with vert offset

### DIFF
--- a/_sass/_06_typography.scss
+++ b/_sass/_06_typography.scss
@@ -83,6 +83,9 @@ p.button a {
 
 
 /* Headlines
+   The hK::before logic is to accomodate a vert. offset for persistent
+   top of page menu. The logic is copied from
+   https://css-tricks.com/hash-tag-links-padding/
 ------------------------------------------------------------------- */
 
 h1, h2, h3, h4, h5, h6 {
@@ -95,6 +98,14 @@ h1 {
     font-size: $font-size-h1;
     margin-top: 0;
 }
+h1::before { 
+  display: block; 
+  content: " "; 
+  margin-top: -60px; 
+  height: 60px; 
+  visibility: hidden; 
+  pointer-events: none;
+}
 h2 {
     font-size: $font-size-h2;
     margin: 1.563em 0 0 0;
@@ -102,17 +113,49 @@ h2 {
     .blog-index h2 {
         margin-top: 0;
     }
+h2::before { 
+  display: block; 
+  content: " "; 
+  margin-top: -60px; 
+  height: 60px; 
+  visibility: hidden; 
+  pointer-events: none;
+}
 h3 {
     font-size: $font-size-h3;
     margin: 1.152em 0 0 0;
+}
+h3::before { 
+  display: block; 
+  content: " "; 
+  margin-top: -50px; 
+  height: 50px; 
+  visibility: hidden; 
+  pointer-events: none;
 }
 h4 {
     font-size: $font-size-h4;
     margin: 1.152em 0 0 0;
 }
+h4::before { 
+  display: block; 
+  content: " "; 
+  margin-top: -50px; 
+  height: 50px; 
+  visibility: hidden; 
+  pointer-events: none;
+}
 h5 {
     font-size: $font-size-h5;
     margin: 1em 0 0 0;
+}
+h5::before { 
+  display: block; 
+  content: " "; 
+  margin-top: -50px; 
+  height: 50px; 
+  visibility: hidden; 
+  pointer-events: none;
 }
 
 


### PR DESCRIPTION
This is to incorporate the idea described [here](https://css-tricks.com/hash-tag-links-padding/) so that internal page anchors accomodate a persistent top menu bar and wind up being rendered just *below* it instead of appearing *behind* it.