### PR TITLE
_11_syntax-highlighting.scss include data-language

### DIFF
--- a/_sass/_11_syntax-highlighting.scss
+++ b/_sass/_11_syntax-highlighting.scss
@@ -4,6 +4,13 @@
 
 .highlight {
     background: #fff;
+    [data-lang]::before {
+    content: attr(data-lang);
+    display: block;
+    text-align: right;
+    margin-right: 5px;
+    text-transform: uppercase;
+    }
     .c     { color: #998; font-style: italic } // Comment
     .err   { color: #a61717; background-color: #e3d2d2 } // Error
     .k     { font-weight: bold } // Keyword


### PR DESCRIPTION
Adds data-language label in top-right corner of highlight
![Screenshot 2021-10-12 3 35 50 AM](https://user-images.githubusercontent.com/3696477/136912712-a76baf72-6f97-4b15-8a48-c83f82786c5b.png)
.