### PR TITLE
show title in navigation also for medium screens

### DIFF
--- a/_includes/_navigation.html
+++ b/_includes/_navigation.html
@@ -8,7 +8,7 @@
   <nav class="top-bar" role="navigation" data-topbar>
     <ul class="title-area">
       <li class="name">
-      <h1 class="show-for-small-only"><a href="{{ site.url }}{{ site.baseurl }}" class="icon-tree"> {{ site.title }}</a></h1>
+      <h1 class="show-for-medium-down"><a href="{{ site.url }}{{ site.baseurl }}" class="icon-tree"> {{ site.title }}</a></h1>
     </li>
        <!-- Remove the class "menu-icon" to get rid of menu icon. Take out "Menu" to just have icon alone -->
       <li class="toggle-topbar menu-icon"><a href="#"><span>Nav</span></a></li>


### PR DESCRIPTION
Problem: Navigation title is there on small, disappears for medium - nothing there
Solution: Show title also on medium screens

![image](https://user-images.githubusercontent.com/564768/166342360-b6003632-82e0-42f6-a601-2a891f6ac8bb.png)
![image](https://user-images.githubusercontent.com/564768/166342418-4351cd6d-2d55-42c6-b1a1-e3fcdbf6b155.png)


See also: https://github.com/kirstin/kirstinheidler.co.uk/issues/10