### PR TITLE
Update Google Analytics and correct mistyped var

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -90,11 +90,14 @@
 	{% endunless %}
 
 	{% if site.google_analytics_tracking_id %}
+	<!-- Global site tag (gtag.js) - Google Analytics -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics_tracking_id }}"></script>
 	<script>
-	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-	ga('create', '{{ site.analytics.google.tracking_id }}', 'auto');
-	ga('send', 'pageview');
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+		gtag('js', new Date());
+
+		gtag('config', '{{ site.google_analytics_tracking_id }}');
 	</script>
-	<script async src='https://www.google-analytics.com/analytics.js'></script>
 	{% endif %}
 


### PR DESCRIPTION
Updated old Google Analytics (analytics.js) to new Global site tag (gtag.js) Google Analytics.

BTW old Google Analytics was not working here because of mistyped variable.