### PR TITLE
Fix `sitemap: false` instruction not working

### DIFF
--- a/_includes/sitemap_collection.xml
+++ b/_includes/sitemap_collection.xml
@@ -1,6 +1,6 @@
 <!-- {{ include.name }}: {{ include.links | size }} links with priority={{ include.priority }}, changefreq={{ include.changefreq }} -->
 {% for link in include.links %}
-	{% unless link.sitemap.exclude or link.published == false %}
+	{% unless link.sitemap == false or link.sitemap.exclude or link.published == false %}
 	<url>
 	<loc>{{ site.url }}{{ site.baseurl }}{{ link.url | remove: 'index.html' }}</loc>
 	{% if link.sitemap.lastmod %}


### PR DESCRIPTION
Some pages in this theme use the `sitemap: false` instruction to prevent their inclusion to the `sitemap.xml` file. Some examples of such pages:
- [404 error page](https://github.com/Phlow/feeling-responsive/blob/db92e5e303aaea3c939f7c5aaad1354868143ee1/pages/pages-root-folder/404.md?plain=1#L6)
- [Redirection example](https://github.com/Phlow/feeling-responsive/blob/db92e5e303aaea3c939f7c5aaad1354868143ee1/pages/redirected_page.md?plain=1#L4)

However this instruction doesn't seem to work. The current [sitemap.xml](https://phlow.github.io/feeling-responsive/sitemap.xml) of this theme's website contains the links to `404.html`, `redirect-page`, `search`, despite all of them have the `sitemap: false` instruction. Apparently the only currently working way to exclude the page from the sitemap is setting the `sitemap.exclude` variable, like it is done [here](https://github.com/Phlow/feeling-responsive/blob/db92e5e303aaea3c939f7c5aaad1354868143ee1/assets/xslt/rss.xslt#L5).

This pull requests corrects the behavior of the `sitemap: false` instruction thus allowing excluding a page from a sitemap both via the `sitemap` and `sitemap.exclude` variables.