### PR TITLE
fix navigation dropdown relative links

### DIFF
--- a/_includes/_navigation.html
+++ b/_includes/_navigation.html
@@ -57,8 +57,10 @@
 
                       {% if dropdown_link.url contains 'http' %}
                         {% assign domain = '' %}
+                        {% assign _baseurl = '' %}
                         {% else %}
                         {% assign domain = site.url %}
+                        {% assign _baseurl = site.baseurl %}
                       {% endif %}
 
                       <li><a {% if dropdown_link.class %}class="{{dropdown_link.class}}"{% endif %} href="{{ domain }}{{ _baseurl }}{{ dropdown_link.url }}"{% if dropdown_link.url contains 'http' %} target="_blank"{% endif %}>{{ dropdown_link.title | escape }}</a></li>
@@ -119,8 +121,10 @@
 
                       {% if dropdown_link.url contains 'http' %}
                         {% assign domain = '' %}
+                        {% assign _baseurl = '' %}
                         {% else %}
                         {% assign domain = site.url %}
+                        {% assign _baseurl = site.baseurl %}
                       {% endif %}
 
                       <li><a {% if dropdown_link.class %}class="{{dropdown_link.class}}"{% endif %} href="{{ domain }}{{ _baseurl }}{{ dropdown_link.url }}"{% if dropdown_link.url contains 'http' %} target="_blank"{% endif %}>{{ dropdown_link.title | escape }}</a></li>


### PR DESCRIPTION
```yml
# _data/navigation.yml
- title: Test
  url: "/"
  side: left
  dropdown:
  - title: Relative
    url: "/subpage/"           # works (becomes `{{site_url}}{{baseurl}}/subpage/`)
  - title: Absolute
    url: "https://github.com"  # was broken (became `{{baseurl}}https://github.com`)
```